### PR TITLE
Load the data for each station into its own hash #2

### DIFF
--- a/load_stations.py
+++ b/load_stations.py
@@ -16,6 +16,12 @@ pipeline = redis_client.pipeline(transaction=False)
 pipeline.delete(STATIONS_KEY)
 
 for station in stations:
+    extended_data = station.extended_data
+    sd = extended_data.elements[0]
+    station_data = {x["name"]: x["value"] for x in sd.data}
+
+    station_key = f"station:{str(station.name).lower()}"
+    pipeline.hmset(station_key, station_data)
     pipeline.geoadd(STATIONS_KEY, station.geometry.x, station.geometry.y, station.name)
 
 pipeline.zcard(STATIONS_KEY)


### PR DESCRIPTION
This pull request is for #2 .

But I have a question that: If I comment out `pipeline.geoadd(...)`, then the Flask app will not be able to search the stations. Would it be the expected one? Thanks!