### PR TITLE
Fix docker image: hiredis missing dependencies 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ ENV FLASK_ENV=development
 
 COPY . .
 
-RUN pip3 install -r requirements.txt
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends -y gcc python3-dev \
+    && pip3 install -r requirements.txt
 
 CMD [ "flask", "run", "--host=0.0.0.0" ]


### PR DESCRIPTION
Closes #16
Adding the dependencies in the docker file, the lack of them was breaking the docker compose feature of the project.